### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,8 @@ Parameters:
 ## 📄 License
 
 This project is licensed under the Apache License 2.0 - see the LICENSE file for details.
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/aaronjmars-web3-research-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/aaronjmars-web3-research-mcp).