### PR TITLE
feat: add direct DeFiLlama API tools (defillama-data, defillama-search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,23 @@ Searches CoinGecko's coin index and returns candidate matches with their CoinGec
 Parameters:
 - query: Search query — name, ticker, or contract address
 
+### defillama-data
+
+Fetches protocol data directly from the DeFiLlama public API — total TVL, per-chain TVL breakdown, fees (24h/7d/30d/all-time), token addresses, fundraising rounds, and links. Bypasses HTML scraping for the most common DeFi-protocol lookup.
+
+Parameters:
+- tokenName: Full protocol/token name (e.g., 'Uniswap')
+- tokenTicker: Ticker symbol (e.g., 'UNI')
+
+No API key required. Uses the free public API. Requests time out after 15s. The protocol index is cached for 5 minutes per process to avoid hammering `/protocols` on every call.
+
+### defillama-search
+
+Searches DeFiLlama's protocol index and returns candidate matches with their slugs, TVL, and category. Useful when the ticker is ambiguous (e.g., multiple protocols with similar names).
+
+Parameters:
+- query: Search query — protocol name, ticker, or slug
+
 ## 📝 Prompts
 
 ### token-research

--- a/src/tools/defiLlamaTool.ts
+++ b/src/tools/defiLlamaTool.ts
@@ -1,0 +1,483 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import fetch from "node-fetch";
+import ResearchStorage from "../storage/researchStorage.js";
+
+const DEFILLAMA_BASE = "https://api.llama.fi";
+const DEFILLAMA_TIMEOUT_MS = 15000;
+const PROTOCOLS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface DLProtocolListEntry {
+  id: string;
+  name: string;
+  symbol?: string | null;
+  slug: string;
+  url?: string | null;
+  description?: string | null;
+  chain?: string | null;
+  chains?: string[];
+  category?: string | null;
+  tvl?: number | null;
+  twitter?: string | null;
+  logo?: string | null;
+}
+
+interface DLProtocolDetail extends DLProtocolListEntry {
+  address?: string | null;
+  audits?: string | null;
+  audit_links?: string[];
+  language?: string | null;
+  currentChainTvls?: Record<string, number>;
+  raises?: Array<{
+    date?: number;
+    name?: string;
+    round?: string;
+    amount?: number;
+    chains?: string[];
+    leadInvestors?: string[];
+    otherInvestors?: string[];
+    valuation?: number;
+  }>;
+  mcap?: number | null;
+}
+
+interface DLFeesSummary {
+  name?: string;
+  total24h?: number | null;
+  total7d?: number | null;
+  total30d?: number | null;
+  totalAllTime?: number | null;
+  change_1d?: number | null;
+  change_7d?: number | null;
+  change_1m?: number | null;
+}
+
+let protocolsCache: { data: DLProtocolListEntry[]; fetchedAt: number } | null =
+  null;
+
+async function dlFetch(path: string): Promise<any> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    "User-Agent": "web3-research-mcp",
+  };
+
+  // node-fetch v2 doesn't support AbortSignal.timeout(); use AbortController.
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), DEFILLAMA_TIMEOUT_MS);
+
+  let response;
+  try {
+    response = await fetch(`${DEFILLAMA_BASE}${path}`, {
+      headers,
+      signal: controller.signal as any,
+    });
+  } catch (err: any) {
+    if (err?.name === "AbortError") {
+      throw new Error(
+        `DeFiLlama request timed out after ${DEFILLAMA_TIMEOUT_MS}ms`
+      );
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (response.status === 429) {
+    throw new Error(
+      "DeFiLlama rate limit hit (429). Wait a minute and retry."
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `DeFiLlama API error ${response.status}: ${response.statusText}`
+    );
+  }
+
+  return response.json();
+}
+
+async function getProtocols(): Promise<DLProtocolListEntry[]> {
+  const now = Date.now();
+  if (
+    protocolsCache &&
+    now - protocolsCache.fetchedAt < PROTOCOLS_CACHE_TTL_MS
+  ) {
+    return protocolsCache.data;
+  }
+  const data = (await dlFetch("/protocols")) as DLProtocolListEntry[];
+  protocolsCache = { data, fetchedAt: now };
+  return data;
+}
+
+interface ResolveProtocolResult {
+  protocol: DLProtocolListEntry;
+  ambiguous: boolean;
+  candidateCount: number;
+  matchedOn: string;
+}
+
+function pickHighestTvl(
+  candidates: DLProtocolListEntry[]
+): DLProtocolListEntry {
+  return [...candidates].sort((a, b) => (b.tvl ?? 0) - (a.tvl ?? 0))[0];
+}
+
+async function resolveProtocol(
+  tokenName: string,
+  tokenTicker: string
+): Promise<ResolveProtocolResult | null> {
+  const protocols = await getProtocols();
+  const tickerUpper = tokenTicker.trim().toUpperCase();
+  const nameLower = tokenName.trim().toLowerCase();
+  const tickerLower = tokenTicker.trim().toLowerCase();
+
+  if (tickerUpper) {
+    const tickerMatches = protocols.filter(
+      (p) => p.symbol?.toUpperCase() === tickerUpper
+    );
+    if (tickerMatches.length > 0) {
+      return {
+        protocol: pickHighestTvl(tickerMatches),
+        ambiguous: tickerMatches.length > 1,
+        candidateCount: tickerMatches.length,
+        matchedOn: `symbol "${tickerUpper}"`,
+      };
+    }
+  }
+
+  if (nameLower) {
+    const nameMatches = protocols.filter(
+      (p) => p.name?.toLowerCase() === nameLower
+    );
+    if (nameMatches.length > 0) {
+      return {
+        protocol: pickHighestTvl(nameMatches),
+        ambiguous: nameMatches.length > 1,
+        candidateCount: nameMatches.length,
+        matchedOn: `name "${tokenName}"`,
+      };
+    }
+  }
+
+  const slugMatches = protocols.filter(
+    (p) => p.slug === nameLower || p.slug === tickerLower
+  );
+  if (slugMatches.length > 0) {
+    return {
+      protocol: pickHighestTvl(slugMatches),
+      ambiguous: slugMatches.length > 1,
+      candidateCount: slugMatches.length,
+      matchedOn: `slug`,
+    };
+  }
+
+  if (nameLower.length >= 3) {
+    const containsMatches = protocols.filter((p) =>
+      p.name?.toLowerCase().includes(nameLower)
+    );
+    if (containsMatches.length > 0) {
+      return {
+        protocol: pickHighestTvl(containsMatches),
+        ambiguous: containsMatches.length > 1,
+        candidateCount: containsMatches.length,
+        matchedOn: `name contains "${tokenName}"`,
+      };
+    }
+  }
+
+  return null;
+}
+
+async function fetchFees(slug: string): Promise<DLFeesSummary | null> {
+  try {
+    return (await dlFetch(
+      `/summary/fees/${encodeURIComponent(slug)}?dataType=dailyFees`
+    )) as DLFeesSummary;
+  } catch {
+    return null;
+  }
+}
+
+const fmtUsd = (n: number | null | undefined, digits = 0): string => {
+  if (n == null || !isFinite(n)) return "n/a";
+  return `$${n.toLocaleString("en-US", { maximumFractionDigits: digits })}`;
+};
+
+const fmtPct = (n: number | null | undefined): string => {
+  if (n == null || !isFinite(n)) return "n/a";
+  return `${n >= 0 ? "+" : ""}${n.toFixed(2)}%`;
+};
+
+function parseAddresses(detail: DLProtocolDetail): string[] {
+  // DeFiLlama uses two formats:
+  // - top-level `address`: "ethereum:0xabc..." (single canonical address)
+  // - `currentChainTvls`: keys like "Ethereum", "Arbitrum-borrowed" (chains used)
+  const lines: string[] = [];
+  if (detail.address && typeof detail.address === "string") {
+    lines.push(`  - ${detail.address}`);
+  }
+  return lines;
+}
+
+function formatProtocolSummary(
+  detail: DLProtocolDetail,
+  fees: DLFeesSummary | null,
+  totalTvl: number | null
+): string {
+  const chainTvls = detail.currentChainTvls ?? {};
+  const chainTvlLines = Object.entries(chainTvls)
+    .filter(([chain]) => !chain.includes("-")) // skip "-borrowed", "-staking" derivatives
+    .sort(([, a], [, b]) => (b ?? 0) - (a ?? 0))
+    .slice(0, 8)
+    .map(([chain, tvl]) => `  - ${chain}: ${fmtUsd(tvl, 0)}`)
+    .join("\n");
+
+  const addressLines = parseAddresses(detail);
+
+  const links: string[] = [];
+  if (detail.url) links.push(`  - Website: ${detail.url}`);
+  if (detail.twitter) links.push(`  - Twitter: https://twitter.com/${detail.twitter}`);
+  if (detail.audit_links && detail.audit_links.length > 0) {
+    links.push(`  - Audits: ${detail.audit_links.slice(0, 3).join(", ")}`);
+  }
+
+  const raises = (detail.raises ?? []).slice(0, 5).map((r) => {
+    const amount =
+      typeof r.amount === "number" ? `$${r.amount.toLocaleString("en-US")}` : "n/a";
+    const date = r.date ? new Date(r.date * 1000).toISOString().slice(0, 10) : "n/a";
+    const round = r.round ?? "round";
+    const lead = r.leadInvestors?.length ? ` — lead: ${r.leadInvestors.join(", ")}` : "";
+    return `  - ${date} ${round}: ${amount}${lead}`;
+  });
+
+  const feesSection: string[] = [];
+  if (fees) {
+    feesSection.push("");
+    feesSection.push("## Fees");
+    feesSection.push(`- 24h: ${fmtUsd(fees.total24h, 0)}`);
+    feesSection.push(`- 7d: ${fmtUsd(fees.total7d, 0)}`);
+    feesSection.push(`- 30d: ${fmtUsd(fees.total30d, 0)}`);
+    feesSection.push(`- All-time: ${fmtUsd(fees.totalAllTime, 0)}`);
+    if (fees.change_1d != null) feesSection.push(`- 24h change: ${fmtPct(fees.change_1d)}`);
+    if (fees.change_7d != null) feesSection.push(`- 7d change: ${fmtPct(fees.change_7d)}`);
+  }
+
+  const lines = [
+    `# ${detail.name}${detail.symbol ? ` (${detail.symbol})` : ""} — DeFiLlama`,
+    detail.category ? `Category: ${detail.category}` : null,
+    detail.chain ? `Primary chain: ${detail.chain}` : null,
+    "",
+    "## TVL",
+    `- Total TVL: ${fmtUsd(totalTvl, 0)}`,
+    "",
+    "## Per-chain TVL",
+    chainTvlLines || "  (none reported)",
+    ...feesSection,
+    "",
+    "## Token addresses",
+    addressLines.length > 0 ? addressLines.join("\n") : "  (none listed)",
+    "",
+    "## Raises",
+    raises.length > 0 ? raises.join("\n") : "  (none listed)",
+    "",
+    "## Links",
+    links.length > 0 ? links.join("\n") : "  (none listed)",
+    "",
+    detail.description ? `## Description\n${detail.description}` : null,
+  ].filter((line) => line !== null);
+
+  return lines.join("\n");
+}
+
+export function registerDeFiLlamaTools(
+  server: McpServer,
+  storage: ResearchStorage
+): void {
+  server.tool(
+    "defillama-data",
+    {
+      tokenName: z
+        .string()
+        .describe("Full protocol/token name (e.g., 'Uniswap')"),
+      tokenTicker: z.string().describe("Ticker symbol (e.g., 'UNI')"),
+    },
+    async ({
+      tokenName,
+      tokenTicker,
+    }: {
+      tokenName: string;
+      tokenTicker: string;
+    }) => {
+      storage.addLogEntry(
+        `Fetching DeFiLlama data for ${tokenName} (${tokenTicker})`
+      );
+
+      try {
+        const resolved = await resolveProtocol(tokenName, tokenTicker);
+        if (!resolved) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text",
+                text: `DeFiLlama: no protocol found matching ${tokenName} (${tokenTicker}). Use \`defillama-search\` to look up candidate slugs.`,
+              },
+            ],
+          };
+        }
+
+        const { protocol: match, ambiguous, candidateCount, matchedOn } =
+          resolved;
+
+        const detail = (await dlFetch(
+          `/protocol/${encodeURIComponent(match.slug)}`
+        )) as DLProtocolDetail;
+
+        const fees = await fetchFees(match.slug);
+
+        // /protocols returns `tvl` as a numeric current TVL (sum across chains).
+        // /protocol/{slug} returns `tvl` as a historical chart array, so we
+        // can't reuse it as a number. Prefer the numeric value from the index.
+        const totalTvl = typeof match.tvl === "number" ? match.tvl : null;
+
+        const summary = formatProtocolSummary(detail, fees, totalTvl);
+        const ambiguityWarning = ambiguous
+          ? `> ⚠️ ${candidateCount} protocols matched on ${matchedOn}; showing highest-TVL match (\`${match.slug}\`). Use \`defillama-search\` to disambiguate.\n\n`
+          : "";
+        const resourceId = `defillama_${match.slug}_${new Date().getTime()}`;
+
+        storage.addToSection("resources", {
+          [resourceId]: {
+            url: `${DEFILLAMA_BASE}/protocol/${match.slug}`,
+            format: "markdown",
+            content: `${ambiguityWarning}${summary}`,
+            title: `DeFiLlama: ${detail.name}${
+              detail.symbol ? ` (${detail.symbol})` : ""
+            }`,
+            source: "DeFiLlama",
+            fetchedAt: new Date().toISOString(),
+          },
+        });
+
+        storage.addToSection("marketData", {
+          [`defillama_${match.slug}`]: {
+            slug: match.slug,
+            name: detail.name,
+            symbol: detail.symbol,
+            category: detail.category,
+            tvl_usd: totalTvl,
+            chains: detail.chains,
+            fees_24h_usd: fees?.total24h ?? null,
+            fees_7d_usd: fees?.total7d ?? null,
+            fees_30d_usd: fees?.total30d ?? null,
+          },
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `${ambiguityWarning}${summary}\n\nSaved as resource: research://resource/${resourceId}`,
+            },
+          ],
+        };
+      } catch (error) {
+        storage.addLogEntry(`DeFiLlama fetch failed: ${error}`);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Error fetching DeFiLlama data: ${error}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.tool(
+    "defillama-search",
+    {
+      query: z
+        .string()
+        .describe(
+          "Search query — protocol name, ticker, or slug. Returns candidate DeFiLlama protocols with their slugs."
+        ),
+    },
+    async ({ query }: { query: string }) => {
+      storage.addLogEntry(`DeFiLlama search: "${query}"`);
+
+      try {
+        const protocols = await getProtocols();
+        const q = query.trim().toLowerCase();
+        const qUpper = query.trim().toUpperCase();
+
+        const scored = protocols
+          .map((p) => {
+            const name = p.name?.toLowerCase() ?? "";
+            const symbol = p.symbol?.toUpperCase() ?? "";
+            const slug = p.slug?.toLowerCase() ?? "";
+
+            let score = 0;
+            if (symbol === qUpper) score += 100;
+            if (name === q) score += 80;
+            if (slug === q) score += 70;
+            if (name.startsWith(q)) score += 30;
+            if (slug.startsWith(q)) score += 20;
+            if (name.includes(q)) score += 10;
+            return { p, score };
+          })
+          .filter((x) => x.score > 0)
+          .sort(
+            (a, b) =>
+              b.score - a.score || (b.p.tvl ?? 0) - (a.p.tvl ?? 0)
+          )
+          .slice(0, 10)
+          .map((x) => x.p);
+
+        if (scored.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `No DeFiLlama matches for "${query}"`,
+              },
+            ],
+          };
+        }
+
+        const lines = scored.map(
+          (p) =>
+            `- ${p.name} (${p.symbol ?? "—"}) — slug: \`${p.slug}\` — TVL: ${fmtUsd(
+              p.tvl,
+              0
+            )}${p.category ? ` — ${p.category}` : ""}`
+        );
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `DeFiLlama matches for "${query}":\n\n${lines.join(
+                "\n"
+              )}\n\nUse \`defillama-data\` with the matching name/ticker for full details.`,
+            },
+          ],
+        };
+      } catch (error) {
+        storage.addLogEntry(`DeFiLlama search failed: ${error}`);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Error searching DeFiLlama: ${error}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import ResearchStorage from "../storage/researchStorage.js";
 import { registerResearchTools } from "./researchTools.js";
 import { registerCoinGeckoTools } from "./coinGeckoTool.js";
+import { registerDeFiLlamaTools } from "./defiLlamaTool.js";
 
 export function registerAllTools(
   server: McpServer,
@@ -9,4 +10,5 @@ export function registerAllTools(
 ): void {
   registerResearchTools(server, storage);
   registerCoinGeckoTools(server, storage);
+  registerDeFiLlamaTools(server, storage);
 }


### PR DESCRIPTION
## Summary

Adds two new tools that hit the DeFiLlama public API directly. The README has been advertising `Multi-Source Analysis across CoinGecko, CoinMarketCap, **DeFiLlama**` for a while, but DeFiLlama lookups currently go through `duck-duck-scrape` + HTML scraping — the same path the README's Limitations section flags as 403-prone. This delivers actual DeFiLlama data the same way #9 / #11 delivered CoinGecko data.

## Changes

- **`src/tools/defiLlamaTool.ts` (new)** — `defillama-data` and `defillama-search` tools. Mirrors the CoinGecko tool's structure, error handling, and ambiguity warnings.
- **`src/tools/index.ts`** — registers the new tools.
- **`README.md`** — adds tool docs in the same format as the CoinGecko entries.

### `defillama-data`
Given `tokenName` + `tokenTicker`, resolves to a protocol slug and fetches:
- Total TVL (numeric, from `/protocols`)
- Per-chain TVL breakdown (top 8 chains, native chains only — filters out `-borrowed`/`-staking`/etc. derivatives)
- Fees from `/summary/fees/{slug}` (24h / 7d / 30d / all-time, when the protocol has a fees adapter)
- Token contract address, audit links, fundraising rounds (top 5), website, twitter
- Saves a markdown summary as a research resource and writes structured fields into `marketData`

Resolution order: exact symbol match → exact name match → slug match → name `includes` (≥3 chars). When multiple protocols match (e.g. forks sharing a ticker), picks the highest-TVL candidate and emits an ambiguity warning pointing to `defillama-search`.

### `defillama-search`
Returns up to 10 candidate protocols ranked by match strength (exact symbol > exact name > slug match > prefix > contains), tiebreaking on TVL. Each line shows name, symbol, slug, TVL, and category — same shape as `coingecko-search`.

## Implementation notes

- **No new dependencies** — reuses `node-fetch` v2 with `AbortController` for the 15s timeout (same pattern as `cgFetch`).
- **`/protocols` cache** — the index payload is ~500KB, so it's cached in-process for 5 min. A single MCP session looking up several protocols only fetches it once.
- **`/protocol/{slug}` quirk** — its top-level `tvl` field is a historical chart array, not a number. Numeric current TVL comes from the `/protocols` index entry; the detail call gives `currentChainTvls` and metadata.
- **Fees endpoint failures are tolerated** — protocols without a fees adapter return 404; that just omits the Fees section instead of failing the whole call.

## Verification

```
$ npm run build
> tsc
# clean
```

```
$ node -e "const m=require('./dist/tools/defiLlamaTool.js'); ..."
Module exports: [ 'registerDeFiLlamaTools' ]
Registered tool: defillama-data with schema keys: [ 'tokenName', 'tokenTicker' ]
Registered tool: defillama-search with schema keys: [ 'query' ]
```

API shapes confirmed against live `/protocol/aave` and `/summary/fees/uniswap` responses.

## Context

Follow-up to #9 (CoinGecko tools) and #11 (CoinGecko hardening). Same author / same pattern — two new tools delivering on a README promise that's currently routed through a known-flaky scraping path.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)