### PR TITLE
fix: 15s request timeout on fetchContent

### DIFF
--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -2,6 +2,8 @@ import * as DDG from "duck-duck-scrape";
 import fetch from "node-fetch";
 import * as cheerio from "cheerio";
 
+const FETCH_CONTENT_TIMEOUT_MS = 15000;
+
 export const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -68,6 +70,13 @@ export async function fetchContent(
   }
 
   for (let i = 0; i <= retries; i++) {
+    // node-fetch v2 doesn't support AbortSignal.timeout(); use AbortController.
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      FETCH_CONTENT_TIMEOUT_MS
+    );
+
     try {
       await sleep(1000 + Math.random() * 2000);
 
@@ -92,6 +101,7 @@ export async function fetchContent(
           "Sec-Fetch-User": "?1",
         },
         redirect: "follow",
+        signal: controller.signal as any,
       });
 
       if (!response.ok) {
@@ -126,13 +136,21 @@ export async function fetchContent(
             return $text("body").text().replace(/\s+/g, " ").trim();
         }
       }
-    } catch (error) {
+    } catch (error: any) {
+      const wrapped =
+        error?.name === "AbortError"
+          ? new Error(
+              `Request to ${url} timed out after ${FETCH_CONTENT_TIMEOUT_MS}ms`
+            )
+          : error;
       if (i < retries) {
         const delay = 3000 * Math.pow(2, i);
         await sleep(delay);
       } else {
-        throw error;
+        throw wrapped;
       }
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 


### PR DESCRIPTION
## Summary
`fetchContent` in `src/utils/searchUtils.ts` was the only HTTP client in this repo without a request timeout. PRs #11 (cgFetch) and #12 (dlFetch) added 15s `AbortController` timeouts to the CoinGecko and DeFiLlama clients but left the lower-level `fetchContent` raw, so a slow or unresponsive arbitrary URL could hang the MCP server until the underlying TCP socket gave up.

## Changes
- `src/utils/searchUtils.ts` — wire `AbortController` + `FETCH_CONTENT_TIMEOUT_MS = 15000` into the existing retry loop. One controller per attempt, cleared in `finally` so timers can't leak. `AbortError` is translated to `Request to <url> timed out after 15000ms` for a clearer final error.

## Context
Found while reading the API tools end-to-end after #11/#12. `fetchContent` is the helper behind `fetch-content`, `research-source`, `research-token`, `search-source`, and `research-with-keywords` — every tool that resolves an arbitrary URL inherits this. The same `AbortController` shape is already in production via cgFetch/dlFetch, so this is an apples-to-apples extension. No new deps, no API changes.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)
