### PR TITLE
fix: align package + README license to MIT to match LICENSE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,4 +203,4 @@ Parameters:
 
 ## 📄 License
 
-This project is licensed under the Apache License 2.0 - see the LICENSE file for details.
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "web3-research-mcp",
       "version": "1.0.1",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",
         "cheerio": "^1.0.0-rc.12",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ai"
   ],
   "author": "aaronjmars",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.9.0",
     "cheerio": "^1.0.0-rc.12",


### PR DESCRIPTION
## Summary
The bundled `LICENSE` file is MIT, but `package.json`, `package-lock.json`, and the README still declared **Apache-2.0**. This aligns all three metadata references to MIT so the declared license matches the license text that actually ships.

## Changes
- `package.json` — `"license": "Apache-2.0"` → `"MIT"`
- `package-lock.json` — root package `license` field → `"MIT"` (mirrors `package.json`)
- `README.md` — "Apache License 2.0" → "MIT License"

## Context
The full-text `LICENSE` file is MIT (added deliberately in commit `786ac52` "Add MIT License"), and the README points readers to "the LICENSE file for details" — which is MIT. The `Apache-2.0` SPDX strings look like stale template leftovers. Because this package is published to npm and indexed on Smithery + Glama, the metadata mismatch means consumers see a different license (Apache-2.0, which carries a patent grant and NOTICE requirements) than the one actually granted (MIT). No `NOTICE` file is present, consistent with MIT being the real license. The only remaining `Apache-2.0` entry in `package-lock.json` belongs to the `typescript` dev dependency and is correct.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)