### PR TITLE
feat(defillama): surface ATH TVL, 30/90/365d history, and market cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ No API key required. Uses the free public tier. Requests time out after 15s.
 
 ### defillama-data
 
-Fetches protocol data directly from the DeFiLlama public API — total TVL, per-chain TVL breakdown, fees (24h/7d/30d/all-time), token addresses, fundraising rounds, and links. Bypasses HTML scraping for the most common DeFi-protocol lookup.
+Fetches protocol data directly from the DeFiLlama public API — total TVL, ATH TVL with date, 30/90/365-day TVL change vs current, market cap, per-chain TVL breakdown, fees (24h/7d/30d/all-time), token addresses, fundraising rounds, and links. Bypasses HTML scraping for the most common DeFi-protocol lookup.
 
 Parameters:
 - tokenName: Full protocol/token name (e.g., 'Uniswap')

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ No API key required. Uses the free public tier. Requests time out after 15s.
 
 ### defillama-data
 
-Fetches protocol data directly from the DeFiLlama public API — total TVL, ATH TVL with date, 30/90/365-day TVL change vs current, market cap, per-chain TVL breakdown, fees (24h/7d/30d/all-time), token addresses, fundraising rounds, and links. Bypasses HTML scraping for the most common DeFi-protocol lookup.
+Fetches protocol data directly from the DeFiLlama public API — total TVL, ATH TVL with date, 30/90/365-day TVL change vs current, market cap (when available — DeFiLlama omits it for many protocols), per-chain TVL breakdown, fees (24h/7d/30d/all-time), token addresses, fundraising rounds, and links. Bypasses HTML scraping for the most common DeFi-protocol lookup.
 
 Parameters:
 - tokenName: Full protocol/token name (e.g., 'Uniswap')

--- a/src/tools/defiLlamaTool.ts
+++ b/src/tools/defiLlamaTool.ts
@@ -52,6 +52,24 @@ interface DLFeesSummary {
   change_1m?: number | null;
 }
 
+interface DLTvlChartPoint {
+  date: number; // unix seconds
+  totalLiquidityUSD: number;
+}
+
+interface TvlHistorySummary {
+  athTvl: number;
+  athDate: number;
+  fromAthPct: number;
+  current: number;
+  d30Ago: number | null;
+  d90Ago: number | null;
+  d365Ago: number | null;
+  change30dPct: number | null;
+  change90dPct: number | null;
+  change365dPct: number | null;
+}
+
 let protocolsCache: { data: DLProtocolListEntry[]; fetchedAt: number } | null =
   null;
 
@@ -189,6 +207,74 @@ async function resolveProtocol(
   return null;
 }
 
+// /protocol/{slug} returns `tvl` as a daily chart array of
+// `{date, totalLiquidityUSD}` (unix seconds). The DLProtocolListEntry
+// type declares `tvl?: number | null;` for the index endpoint, so we cast
+// at the use site rather than narrowing on the detail type.
+function computeTvlHistory(
+  detail: DLProtocolDetail,
+  currentTvl: number | null
+): TvlHistorySummary | null {
+  const chart = (detail as { tvl?: unknown }).tvl;
+  if (!Array.isArray(chart) || chart.length === 0) return null;
+
+  const validPoints = chart.filter(
+    (p): p is DLTvlChartPoint =>
+      typeof p?.date === "number" &&
+      typeof p?.totalLiquidityUSD === "number" &&
+      isFinite(p.totalLiquidityUSD)
+  );
+  if (validPoints.length === 0) return null;
+
+  let athTvl = 0;
+  let athDate = 0;
+  for (const p of validPoints) {
+    if (p.totalLiquidityUSD > athTvl) {
+      athTvl = p.totalLiquidityUSD;
+      athDate = p.date;
+    }
+  }
+
+  const last = validPoints[validPoints.length - 1];
+  // Prefer the index `currentTvl` (matches the rendered "Total TVL"); fall
+  // back to the latest chart point if the index value is missing.
+  const current =
+    typeof currentTvl === "number" ? currentTvl : last.totalLiquidityUSD;
+  const nowSec = last.date;
+
+  const findAgo = (daysAgo: number): number | null => {
+    const target = nowSec - daysAgo * 86400;
+    if (target < validPoints[0].date) return null;
+    // Chart is chronologically ordered; walk back to the latest snapshot ≤ target.
+    for (let i = validPoints.length - 1; i >= 0; i--) {
+      if (validPoints[i].date <= target) return validPoints[i].totalLiquidityUSD;
+    }
+    return null;
+  };
+
+  const d30 = findAgo(30);
+  const d90 = findAgo(90);
+  const d365 = findAgo(365);
+
+  const pctChange = (prev: number | null): number | null => {
+    if (prev == null || prev === 0) return null;
+    return ((current - prev) / prev) * 100;
+  };
+
+  return {
+    athTvl,
+    athDate,
+    fromAthPct: athTvl > 0 ? ((current - athTvl) / athTvl) * 100 : 0,
+    current,
+    d30Ago: d30,
+    d90Ago: d90,
+    d365Ago: d365,
+    change30dPct: pctChange(d30),
+    change90dPct: pctChange(d90),
+    change365dPct: pctChange(d365),
+  };
+}
+
 async function fetchFees(slug: string): Promise<DLFeesSummary | null> {
   try {
     return (await dlFetch(
@@ -223,7 +309,8 @@ function parseAddresses(detail: DLProtocolDetail): string[] {
 function formatProtocolSummary(
   detail: DLProtocolDetail,
   fees: DLFeesSummary | null,
-  totalTvl: number | null
+  totalTvl: number | null,
+  tvlHistory: TvlHistorySummary | null
 ): string {
   const chainTvls = detail.currentChainTvls ?? {};
   const chainTvlLines = Object.entries(chainTvls)
@@ -232,6 +319,41 @@ function formatProtocolSummary(
     .slice(0, 8)
     .map(([chain, tvl]) => `  - ${chain}: ${fmtUsd(tvl, 0)}`)
     .join("\n");
+
+  const tvlHistoryLines: string[] = [];
+  if (tvlHistory) {
+    const athDateStr = tvlHistory.athDate
+      ? new Date(tvlHistory.athDate * 1000).toISOString().slice(0, 10)
+      : "n/a";
+    tvlHistoryLines.push(
+      `- ATH TVL: ${fmtUsd(tvlHistory.athTvl, 0)} (${athDateStr})`
+    );
+    tvlHistoryLines.push(`- From ATH: ${fmtPct(tvlHistory.fromAthPct)}`);
+    if (tvlHistory.d30Ago != null) {
+      tvlHistoryLines.push(
+        `- 30d ago: ${fmtUsd(tvlHistory.d30Ago, 0)} (change ${fmtPct(
+          tvlHistory.change30dPct
+        )})`
+      );
+    }
+    if (tvlHistory.d90Ago != null) {
+      tvlHistoryLines.push(
+        `- 90d ago: ${fmtUsd(tvlHistory.d90Ago, 0)} (change ${fmtPct(
+          tvlHistory.change90dPct
+        )})`
+      );
+    }
+    if (tvlHistory.d365Ago != null) {
+      tvlHistoryLines.push(
+        `- 365d ago: ${fmtUsd(tvlHistory.d365Ago, 0)} (change ${fmtPct(
+          tvlHistory.change365dPct
+        )})`
+      );
+    }
+  }
+  if (detail.mcap != null) {
+    tvlHistoryLines.push(`- Market cap: ${fmtUsd(detail.mcap, 0)}`);
+  }
 
   const addressLines = parseAddresses(detail);
 
@@ -270,6 +392,7 @@ function formatProtocolSummary(
     "",
     "## TVL",
     `- Total TVL: ${fmtUsd(totalTvl, 0)}`,
+    ...tvlHistoryLines,
     "",
     "## Per-chain TVL",
     chainTvlLines || "  (none reported)",
@@ -337,11 +460,13 @@ export function registerDeFiLlamaTools(
         const fees = await fetchFees(match.slug);
 
         // /protocols returns `tvl` as a numeric current TVL (sum across chains).
-        // /protocol/{slug} returns `tvl` as a historical chart array, so we
-        // can't reuse it as a number. Prefer the numeric value from the index.
+        // /protocol/{slug} returns `tvl` as a historical chart array, which
+        // `computeTvlHistory` walks for ATH + 30/90/365-day comparisons.
+        // Prefer the numeric index value for the headline "Total TVL".
         const totalTvl = typeof match.tvl === "number" ? match.tvl : null;
+        const tvlHistory = computeTvlHistory(detail, totalTvl);
 
-        const summary = formatProtocolSummary(detail, fees, totalTvl);
+        const summary = formatProtocolSummary(detail, fees, totalTvl, tvlHistory);
         const ambiguityWarning = ambiguous
           ? `> ⚠️ ${candidateCount} protocols matched on ${matchedOn}; showing highest-TVL match (\`${match.slug}\`). Use \`defillama-search\` to disambiguate.\n\n`
           : "";
@@ -367,6 +492,13 @@ export function registerDeFiLlamaTools(
             symbol: detail.symbol,
             category: detail.category,
             tvl_usd: totalTvl,
+            tvl_ath_usd: tvlHistory?.athTvl ?? null,
+            tvl_ath_date: tvlHistory?.athDate ?? null,
+            tvl_from_ath_pct: tvlHistory?.fromAthPct ?? null,
+            tvl_change_30d_pct: tvlHistory?.change30dPct ?? null,
+            tvl_change_90d_pct: tvlHistory?.change90dPct ?? null,
+            tvl_change_365d_pct: tvlHistory?.change365dPct ?? null,
+            mcap_usd: detail.mcap ?? null,
             chains: detail.chains,
             fees_24h_usd: fees?.total24h ?? null,
             fees_7d_usd: fees?.total7d ?? null,

--- a/src/tools/defiLlamaTool.ts
+++ b/src/tools/defiLlamaTool.ts
@@ -6,6 +6,7 @@ import ResearchStorage from "../storage/researchStorage.js";
 const DEFILLAMA_BASE = "https://api.llama.fi";
 const DEFILLAMA_TIMEOUT_MS = 15000;
 const PROTOCOLS_CACHE_TTL_MS = 5 * 60 * 1000;
+const STALE_CHART_THRESHOLD_SEC = 7 * 86400;
 
 interface DLProtocolListEntry {
   id: string;
@@ -58,9 +59,9 @@ interface DLTvlChartPoint {
 }
 
 interface TvlHistorySummary {
-  athTvl: number;
-  athDate: number;
-  fromAthPct: number;
+  athTvl: number | null;
+  athDate: number | null;
+  fromAthPct: number | null;
   current: number;
   d30Ago: number | null;
   d90Ago: number | null;
@@ -68,6 +69,9 @@ interface TvlHistorySummary {
   change30dPct: number | null;
   change90dPct: number | null;
   change365dPct: number | null;
+  // Date (unix seconds) of the last chart point, set only when the chart is
+  // more than STALE_CHART_THRESHOLD_SEC behind wall-clock (stale/delisted).
+  staleChartDate: number | null;
 }
 
 let protocolsCache: { data: DLProtocolListEntry[]; fetchedAt: number } | null =
@@ -226,6 +230,10 @@ function computeTvlHistory(
   );
   if (validPoints.length === 0) return null;
 
+  // The live API returns the chart date-ascending, but that's unenforced;
+  // sort defensively since the window math below walks from the end.
+  validPoints.sort((a, b) => a.date - b.date);
+
   let athTvl = 0;
   let athDate = 0;
   for (const p of validPoints) {
@@ -240,7 +248,14 @@ function computeTvlHistory(
   // back to the latest chart point if the index value is missing.
   const current =
     typeof currentTvl === "number" ? currentTvl : last.totalLiquidityUSD;
+  // Windows anchor to the last chart point (the right call for sparse charts),
+  // but for stale/delisted protocols "30d ago" then silently means "30d before
+  // the last datapoint" — surface that instead of staying quiet.
   const nowSec = last.date;
+  const staleChartDate =
+    Date.now() / 1000 - last.date > STALE_CHART_THRESHOLD_SEC
+      ? last.date
+      : null;
 
   const findAgo = (daysAgo: number): number | null => {
     const target = nowSec - daysAgo * 86400;
@@ -261,10 +276,14 @@ function computeTvlHistory(
     return ((current - prev) / prev) * 100;
   };
 
+  // An all-zero chart has no meaningful ATH; null lets the formatter skip
+  // those lines instead of rendering "ATH TVL: $0 (n/a)".
+  const hasAth = athTvl > 0;
+
   return {
-    athTvl,
-    athDate,
-    fromAthPct: athTvl > 0 ? ((current - athTvl) / athTvl) * 100 : 0,
+    athTvl: hasAth ? athTvl : null,
+    athDate: hasAth ? athDate : null,
+    fromAthPct: hasAth ? ((current - athTvl) / athTvl) * 100 : null,
     current,
     d30Ago: d30,
     d90Ago: d90,
@@ -272,6 +291,7 @@ function computeTvlHistory(
     change30dPct: pctChange(d30),
     change90dPct: pctChange(d90),
     change365dPct: pctChange(d365),
+    staleChartDate,
   };
 }
 
@@ -322,13 +342,15 @@ function formatProtocolSummary(
 
   const tvlHistoryLines: string[] = [];
   if (tvlHistory) {
-    const athDateStr = tvlHistory.athDate
-      ? new Date(tvlHistory.athDate * 1000).toISOString().slice(0, 10)
-      : "n/a";
-    tvlHistoryLines.push(
-      `- ATH TVL: ${fmtUsd(tvlHistory.athTvl, 0)} (${athDateStr})`
-    );
-    tvlHistoryLines.push(`- From ATH: ${fmtPct(tvlHistory.fromAthPct)}`);
+    if (tvlHistory.athTvl != null) {
+      const athDateStr = tvlHistory.athDate
+        ? new Date(tvlHistory.athDate * 1000).toISOString().slice(0, 10)
+        : "n/a";
+      tvlHistoryLines.push(
+        `- ATH TVL: ${fmtUsd(tvlHistory.athTvl, 0)} (${athDateStr})`
+      );
+      tvlHistoryLines.push(`- From ATH: ${fmtPct(tvlHistory.fromAthPct)}`);
+    }
     if (tvlHistory.d30Ago != null) {
       tvlHistoryLines.push(
         `- 30d ago: ${fmtUsd(tvlHistory.d30Ago, 0)} (change ${fmtPct(
@@ -348,6 +370,14 @@ function formatProtocolSummary(
         `- 365d ago: ${fmtUsd(tvlHistory.d365Ago, 0)} (change ${fmtPct(
           tvlHistory.change365dPct
         )})`
+      );
+    }
+    if (tvlHistory.staleChartDate != null) {
+      const staleDateStr = new Date(tvlHistory.staleChartDate * 1000)
+        .toISOString()
+        .slice(0, 10);
+      tvlHistoryLines.push(
+        `- Note: TVL chart last updated ${staleDateStr}; ATH/history windows are relative to that date.`
       );
     }
   }
@@ -493,7 +523,11 @@ export function registerDeFiLlamaTools(
             category: detail.category,
             tvl_usd: totalTvl,
             tvl_ath_usd: tvlHistory?.athTvl ?? null,
-            tvl_ath_date: tvlHistory?.athDate ?? null,
+            // ISO date, matching the rendered summary and the ISO-string
+            // convention of stored records (e.g. `fetchedAt`).
+            tvl_ath_date: tvlHistory?.athDate
+              ? new Date(tvlHistory.athDate * 1000).toISOString().slice(0, 10)
+              : null,
             tvl_from_ath_pct: tvlHistory?.fromAthPct ?? null,
             tvl_change_30d_pct: tvlHistory?.change30dPct ?? null,
             tvl_change_90d_pct: tvlHistory?.change90dPct ?? null,


### PR DESCRIPTION
## Summary
`defillama-data` already fetches `/protocol/{slug}`, which returns the daily TVL chart and market cap — but the chart was being thrown away (the code explicitly used the index's current TVL number) and `mcap` was ignored entirely. This walks the chart for ATH TVL + date, % from ATH, and 30/90/365-day historical TVL with change-vs-current, plus surfaces `mcap`. No new network calls.

## Changes
- `src/tools/defiLlamaTool.ts` — new `computeTvlHistory` helper, new `TvlHistorySummary` type, `formatProtocolSummary` accepts `tvlHistory` and renders the new lines under `## TVL`. Cast at the use site since `DLProtocolListEntry` types `tvl` as `number|null` (correct for `/protocols`) while `/protocol/{slug}` returns an array. New `marketData` fields: `tvl_ath_usd`, `tvl_ath_date`, `tvl_from_ath_pct`, `tvl_change_{30,90,365}d_pct`, `mcap_usd`.
- `README.md` — `defillama-data` description mentions the new fields.

## Sample output (AAVE V3, 2026-06-10)
```
## TVL
- Total TVL: \$11,544,181,997
- ATH TVL: \$45,443,859,638 (2025-10-07)
- From ATH: -74.60%
- 30d ago: \$14,578,244,918 (change -20.81%)
- 90d ago: \$24,730,031,496 (change -53.32%)
- 365d ago: \$25,134,471,137 (change -54.07%)
- Market cap: \$1,528,564,696
```

## Context
Smoke-tested against `/protocol/aave-v3`, `/protocol/uniswap-v4`, and edge cases (empty chart, missing chart, all-invalid points → all return null). \`npm run build\` clean. Continues the `feat: add direct …` trajectory from #9/#11/#12/#14/#16 — same shape (richer summary, ambiguity warnings unchanged), no new endpoints.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)