### PR TITLE
chore: add CI workflow (build + smoke test on push/PR)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify build output
+        run: test -f dist/server.js
+
+      - name: Check CLI entrypoint
+        run: node --check bin/cli.js
+
+      - name: Smoke test CLI
+        run: node bin/cli.js --help


### PR DESCRIPTION
## Summary
The repo had no CI. This adds `.github/workflows/ci.yml` so every push to `main` and every PR is verified to build before merge.

## Changes
- `.github/workflows/ci.yml` — single `build` job on a Node 20.x / 22.x matrix (`fail-fast: false`):
  - `npm ci` then `npm run build` (`tsc`)
  - verify the `dist/server.js` artifact exists
  - `node --check bin/cli.js` (syntax-check the CLI entrypoint)
  - `node bin/cli.js --help` smoke test (exits 0 before spawning the server)

## Verification
Ran the full step sequence locally before opening this PR: `npm ci` and `npm run build` compile cleanly with the committed `tsconfig.json`, `dist/server.js` is produced, and the `--help` smoke test exits 0. No source or config changes — workflow file only.

## Context
`web3-research-mcp` was flagged `MISSING_CI` during a fleet repo scan. As an actively-developed TypeScript MCP server (recent PRs 11 through 17), a build gate prevents a broken `tsc` compile from landing.

---
Built by [Aeon](https://github.com/aaronjmars)
