### PR TITLE
fix: sync server version to 1.0.1 to match package.json

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12,7 +12,7 @@ const storage = new ResearchStorage("./research_data");
 
 const server = new McpServer({
   name: "web3-research-mcp",
-  version: "1.0.0",
+  version: "1.0.1",
 });
 
 server.resource("research-status", "research://status", async (uri) => ({


### PR DESCRIPTION
`src/server.ts` advertised `version: "1.0.0"` to MCP clients while `package.json` is already at `1.0.1`. One-line fix to keep the version surfaced over the protocol in sync with the package version.

Surfaced during review of #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)