### PR TITLE
chore: npm auto-publish (provenance) + sync version to 1.0.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: publish
+on:
+  push:
+    tags: ["v*"]
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - run: npm install
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web3-research-mcp",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "Deep Research for crypto - free & fully local",
   "main": "dist/server.js",
   "type": "module",


### PR DESCRIPTION
Adds a tag-triggered `npm publish --provenance` workflow (verified 'Built and signed on GitHub Actions' badge on npmjs). Release future versions with: `npm version <patch|minor|major> && git push --follow-tags`. The NPM_TOKEN repo secret is set.