### PR TITLE
security: bump @hono/node-server to 2.0.x (transitive)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,12 +26,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "overrides": {
+    "@hono/node-server": "^2.0.5"
   }
 }


### PR DESCRIPTION
## Security: transitive dependency bump (Dependabot)

The alert is transitive (present only in `package-lock.json`).

| Package | From | To | Method |
| --- | --- | --- | --- |
| @hono/node-server | 1.19.14 | 2.0.11 | override `^2.0.5` |

`@hono/node-server` resolves under `@modelcontextprotocol/sdk` (pins `^1.19.9`), so `npm update` alone could only reach 1.19.15. Added an `overrides` entry to force `^2.0.5`. Direct dependency `zod` (v4) left untouched. Lockfile regenerated; clean `npm install` verified. No production build run.
