### PR TITLE
security: bump fast-uri to 3.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -989,9 +989,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Security: Dependabot alert fix (second wave)

Regenerates `package-lock.json` to pull in the patched transitive dependency.

### Fixed
- **fast-uri** -> 3.1.4 (vulnerable range `>= 3.0.0, <= 3.1.3`, high severity). In range via `ajv`, so a plain `npm update fast-uri` was sufficient - no override needed.

### Method
- `npm update fast-uri`; `npm ls fast-uri` confirms `fast-uri@3.1.4`.
- `npm` reports 0 vulnerabilities. Only `package-lock.json` changed. No production build run.
