### PR TITLE
chore: migrate Web and News search to ddg-kit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cheerio": "^1.0.0-rc.12",
+        "ddg-kit": "^0.1.0",
         "duck-duck-scrape": "^2.2.1",
         "zod": "^4.4.3"
       },
@@ -707,6 +708,72 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/ddg-kit": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ddg-kit/-/ddg-kit-0.1.0.tgz",
+      "integrity": "sha512-8rXECjpAh+dLDtpon+dvF4hnXmskja2MPdIaBNlex7IPZlE04hE42B2+3h1G2MfK41bRFWj5Babu6qUXhNeeDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cheerio": "1.0.0",
+        "undici": "6.28.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/ddg-kit/node_modules/cheerio": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^9.1.0",
+        "parse5": "^7.1.2",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^6.19.5",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/ddg-kit/node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "node_modules/ddg-kit/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -926,6 +993,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1130,6 +1198,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
       "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1916,6 +1985,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cheerio": "^1.0.0-rc.12",
+    "ddg-kit": "^0.1.0",
     "duck-duck-scrape": "^2.2.1",
     "zod": "^4.4.3"
   },

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -1,11 +1,13 @@
 import {
   search,
   searchNews,
-  searchImages,
-  searchVideos,
   SafeSearchType,
   type SearchResults,
   type NewsSearchResults,
+} from "ddg-kit";
+import {
+  searchImages,
+  searchVideos,
   type ImageSearchResults,
   type VideoSearchResults,
 } from "duck-duck-scrape";


### PR DESCRIPTION
## Summary

This PR performs a partial search-client migration:

- Web search now imports `search`, `SearchResults`, and `SafeSearchType` from `ddg-kit`.
- News search now imports `searchNews` and `NewsSearchResults` from `ddg-kit`.
- Image and video search remain on `duck-duck-scrape`.

The existing `performSearch` routing and retry behavior remain unchanged. This
keeps the current Images/Videos behavior stable while the Web/News dependency
seam moves to the maintained compatibility client.

## Why

`ddg-kit` currently provides a verified Web/News compatibility surface. Its
`0.1.0` release has offline fixtures, packed ESM/CommonJS checks, and explicit
failure handling. This PR adopts that surface without claiming that the
package already replaces the media APIs.

Images and Videos use different options and result schemas. They will remain
on `duck-duck-scrape` until the separate ddg-kit P1 media work is released and
verified.

## Downstream adoption evidence

- [OpenCandle PR #145](https://github.com/Kahtaf/OpenCandle/pull/145) merged the
  Web/News migration in merge commit
  [`c7a7af0`](https://github.com/Kahtaf/OpenCandle/commit/c7a7af0bac101f689134e0474876a28ac03c1c23).
  Its maintainer validation included five passing checks and one live News
  query.
- [`intercept-mcp` PR #6](https://github.com/bighippoman/intercept-mcp/pull/6)
  also merged the Web-search migration in merge commit
  [`700b10a`](https://github.com/bighippoman/intercept-mcp/commit/700b10af9f334735aae07f186160efbf17b1a7c2).

These merges are evidence that downstream maintainers accepted the focused
Web/News compatibility change. They are not a production SLA or a claim that
DuckDuckGo provides a supported public contract.

## Validation

- `npm run build` passes (`tsc`).
- No live DuckDuckGo request was made for this PR.
- `duck-duck-scrape` remains a runtime dependency because Images and Videos
  still use it.
