### PR TITLE
security: bump vulnerable deps (Dependabot alerts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -989,9 +989,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1126,9 +1126,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "node": ">=18.0.0"
   },
   "overrides": {
-    "@hono/node-server": "^2.0.5"
+    "@hono/node-server": "^2.0.5",
+    "hono": "^4.12.34",
+    "fast-uri": "^3.1.5"
   }
 }


### PR DESCRIPTION
## Summary

Remediates the two open Dependabot alerts (both high severity) in this repo. Both packages are transitive dependencies, so the fix is applied via `package.json` `overrides` and a regenerated `package-lock.json`.

| Package | Old | New | Patched target | Chain |
| --- | --- | --- | --- | --- |
| hono | 4.12.27 | 4.13.0 | >= 4.12.34 | `@modelcontextprotocol/sdk` (direct dep `hono@^4.11.4`) + `@hono/node-server` peer |
| fast-uri | 3.1.4 | 3.1.5 | >= 3.1.5 | `@modelcontextprotocol/sdk` -> `ajv` -> `fast-uri` |

## Changes

- `package.json`: added `"hono": "^4.12.34"` and `"fast-uri": "^3.1.5"` to the existing `overrides` block (alongside the pre-existing `@hono/node-server` override).
- `package-lock.json`: regenerated with `npm install --package-lock-only`. hono resolved to 4.13.0 (the latest 4.x, above the 4.12.34 patch), fast-uri to 3.1.5.

Only `package.json` and `package-lock.json` are touched. No `node_modules` committed.

## hono transport note (safe)

This MCP server is **stdio-only** - `src/server.ts` connects via `StdioServerTransport` and never instantiates an HTTP/SSE server. hono / `@hono/node-server` are only present transitively through `@modelcontextprotocol/sdk` and are not exercised by this server's runtime. The hono bump is a minor 4.x -> 4.x update (not a major), so no HTTP transport smoke-test is required.
