### PR TITLE
Add founder credit + link to aaronjmars.com

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -229,3 +229,7 @@ Parameters:
 ## 📄 License
 
 This project is licensed under the MIT License - see the LICENSE file for details.
+
+---
+
+Built by [Aaron Elijah Mars](https://aaronjmars.com), founder of Aeon and MiroShark · [@aaronjmars](https://github.com/aaronjmars)


### PR DESCRIPTION
Adds a footer credit linking back to the personal hub, so the profile <-> project link is reciprocal (what makes a sameAs edge count).

One line appended to the README; no other change.